### PR TITLE
Changed to usage of setter when setting the resultSet of the operation.

### DIFF
--- a/ux/data/proxy/WebSocket.js
+++ b/ux/data/proxy/WebSocket.js
@@ -325,7 +325,7 @@ Ext.define ('Ext.ux.data.proxy.WebSocket', {
 			
 			delete me.callbacks[event];
 			
-			opt.resultSet = resultSet;
+			opt.setResultSet(resultSet);
 			opt.scope = fun.scope;
 			
 			opt.setCompleted ();


### PR DESCRIPTION
Prior to this change, I was not able to read records into the store as the respective member of operation is now called _resultSet.

I have not tested it with your code-base, but as the change is minor it should work. I would recommend testing against your Sencha Touch version and Sencha Touch 2.2.1 (I had this in use when the issue occured).
