### PR TITLE
Update to Ext JS 5 (fixes wilk/Ext.ux.data.proxy.WebSocket#12)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,6 @@
     "Gruntfile.js"
   ],
   "dependencies": {
-    "ext.ux.websocket": "~0.0.4"
+    "ext.ux.websocket": "~1.0.0"
   }
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -18,7 +18,11 @@ Ext.onReady(function () {
             url: 'ws://localhost:9001',
             reader: {
                 type: 'json',
-                root: 'user'
+                rootProperty: 'data'
+            },
+            writer: {
+                type: 'json',
+                writeAllFields: true
             }
         }
     });
@@ -41,9 +45,14 @@ Ext.onReady(function () {
             clicksToEdit: 1
         })],
 
-        columns: [{
+        columns: [
+            /*{
+            // rownumberer doesn't work in 5.0.0:
+            // EXTJS-13759 Rownumberer/Action Column causes error when updating row.
+            // Fixed in Ext JS 5.0.1.
             xtype: 'rownumberer'
-        } , {
+        } , */
+            {
             text: 'ID',
             dataIndex: 'id',
             hidden: true
@@ -137,7 +146,7 @@ Ext.onReady(function () {
 
     var treeStore = Ext.create('Ext.data.TreeStore', {
         storeId: 'myTreeStore',
-        autoLoad: true,
+        autoLoad: false,
         model: 'TreeModel',
         proxy: {
             type: 'websocket',
@@ -151,7 +160,7 @@ Ext.onReady(function () {
             },
             reader: {
                 type: 'json',
-                root: 'children'
+                rootProperty: 'data'
             }
         },
         root: {

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,11 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Ext.ux.data.proxy.WebSocket</title>
-		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext-4.2.0-gpl/resources/css/ext-all.css"/>
-		<script src="http://cdn.sencha.com/ext-4.2.0-gpl/ext-all.js"></script>
+		<script src="http://cdn.sencha.com/ext/gpl/5.0.0/build/ext-all-debug.js"></script>
+		<script src="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-charts/build/ext-charts-debug.js"></script>
+		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all-debug.css"/>
+		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-theme-crisp/build/ext-theme-crisp-debug.js">
+
 		<script src="demo.js"></script>
 	</head>
 </html>

--- a/demo/server.js
+++ b/demo/server.js
@@ -39,13 +39,17 @@ wss.on('connection', function (ws) {
 
     ws.send(JSON.stringify({
         event: 'read' ,
-        data: users
+        data: {
+            data: users,
+            success: true
+        }
     }));
 
     ws.send(JSON.stringify({
         event: 'user/read' ,
         data: {
-            children: users
+            data: users,
+            success: true
         }
     }));
 
@@ -65,13 +69,33 @@ wss.on('connection', function (ws) {
 
             wss.broadcast(JSON.stringify({
                 event: 'create' ,
-                data: message.data
+                data: {
+                    data: message.data,
+                    success: true
+                }
+            }));
+            wss.broadcast(JSON.stringify({
+                event: 'user/create' ,
+                data: {
+                    data: message.data,
+                    success: true
+                }
             }));
         }
         else if (event === 'read') {
             ws.send(JSON.stringify({
                 event: 'read' ,
-                data: users
+                data: {
+                    data: users,
+                    success: true
+                }
+            }));
+            ws.send(JSON.stringify({
+                event: 'user/read' ,
+                data: {
+                    data: users,
+                    success: true
+                }
             }));
         }
         else if (event === 'update') {
@@ -89,7 +113,17 @@ wss.on('connection', function (ws) {
 
             wss.broadcast(JSON.stringify({
                 event: 'update' ,
-                data: message.data
+                data: {
+                    data: message.data,
+                    success: true
+                }
+            }));
+            wss.broadcast(JSON.stringify({
+                event: 'user/update' ,
+                data: {
+                    data: message.data,
+                    success: true
+                }
             }));
         }
         else if (event === 'destroy') {
@@ -107,7 +141,17 @@ wss.on('connection', function (ws) {
 
             wss.broadcast(JSON.stringify({
                 event: 'destroy' ,
-                data: message.data
+                data: {
+                    data: message.data,
+                    success: true
+                }
+            }));
+            wss.broadcast(JSON.stringify({
+                event: 'user/destroy' ,
+                data: {
+                    data: message.data,
+                    success: true
+                }
             }));
         }
     });


### PR DESCRIPTION
This version does work on Ext JS 5.

Known issue: Chart in Ext JS 5 does not render correctly after updates in the store.
Known issue: Removed `rownumberer` from the demo grid because of bug EXTJS-13759 (fixed in Ext JS 5.0.1).
