### PR TITLE
update to Ext JS 5.0.1

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -46,12 +46,9 @@ Ext.onReady(function () {
         })],
 
         columns: [
-            /*{
-            // rownumberer doesn't work in 5.0.0:
-            // EXTJS-13759 Rownumberer/Action Column causes error when updating row.
-            // Fixed in Ext JS 5.0.1.
+            {
             xtype: 'rownumberer'
-        } , */
+        } ,
             {
             text: 'ID',
             dataIndex: 'id',
@@ -114,18 +111,18 @@ Ext.onReady(function () {
         store: store,
 
         axes: [{
-            type: 'Category',
+            type: 'category',
             position: 'bottom',
             fields: ['name']
         } , {
-            type: 'Numeric',
+            type: 'numeric',
             position: 'left',
             minimum: 0,
             fields: ['age']
         }],
 
         series: [{
-            type: 'column',
+            type: 'bar',
             axis: 'left',
             xField: 'name',
             yField: 'age'

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,10 +3,10 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Ext.ux.data.proxy.WebSocket</title>
-		<script src="http://cdn.sencha.com/ext/gpl/5.0.0/build/ext-all-debug.js"></script>
-		<script src="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-charts/build/ext-charts-debug.js"></script>
-		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all-debug.css"/>
-		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.0/packages/ext-theme-crisp/build/ext-theme-crisp-debug.js">
+		<script src="http://cdn.sencha.com/ext/gpl/5.0.1/build/ext-all-debug.js"></script>
+		<script src="http://cdn.sencha.com/ext/gpl/5.0.1/packages/sencha-charts/build/sencha-charts-debug.js"></script>
+		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.1/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all-debug.css"/>
+		<link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.0.1/packages/ext-theme-crisp/build/ext-theme-crisp-debug.js">
 
 		<script src="demo.js"></script>
 	</head>


### PR DESCRIPTION
There were some issues with the proxy demo in v1.0.0 due to Ext JS 5.0.0 bugs that have been fixed in 5.0.1.
Changes in detail:
- switch to Ext JS 5.0.1
- rownumberer grid column is back
- use the new Sencha Charts package

The proxy demo is now again fully functional.
